### PR TITLE
Inject codeql job

### DIFF
--- a/.github/workflows/codeql-results.yml
+++ b/.github/workflows/codeql-results.yml
@@ -51,7 +51,7 @@ jobs:
       with:
         github-token: ${{ secrets.GH_TOKEN }}
         script: |
-           const script = require('./src/get-codeql-results.js')
+           const script = require('./src/wait-on-codeql-run.js')
                   
            // note: owner is now the organization the FORK lives in:
            const owner = "${{ needs.find-action-name.outputs.request_owner }}"

--- a/.github/workflows/codeql-results.yml
+++ b/.github/workflows/codeql-results.yml
@@ -28,8 +28,8 @@ jobs:
             let repo="image-actions"
 
             // this private repo has 1 code scanning alerts
-            owner="Microsoft-Bootcamp"
-            repo="demo-rob"
+            // owner="Microsoft-Bootcamp"
+            // repo="demo-rob"
 
             console.log(`::set-output name=action::${action}`)
             console.log(`::set-output name=owner::${actionOwner}`)

--- a/.github/workflows/issue-labeled-as-security-scan.yml
+++ b/.github/workflows/issue-labeled-as-security-scan.yml
@@ -250,7 +250,7 @@ jobs:
                   
            // note: owner is now the organization the FORK lives in:
            const owner = process.env.owner
-           const repo = "${{ needs.find-action-name.outputs.request_repo }}"
+           const repo = "${{ needs.find-action-name.outputs.name }}"
 
            console.log(await script({github, owner, repo}))        
 

--- a/.github/workflows/issue-labeled-as-security-scan.yml
+++ b/.github/workflows/issue-labeled-as-security-scan.yml
@@ -211,16 +211,21 @@ jobs:
         owner: ${{needs.find-action-name.outputs.owner}}
         org: rajbos-actions-test # todo: make central parameter
 
-    # since dependabot alerts and dependency graph is enabled on the organization level, we only need to add a CodeQL setup
-    # for it we need to inject the default CodeQL config into the forked action repository
+  # since dependabot alerts and dependency graph is enabled on the organization level, but that will not be enabled on new forks
+  # we need to enable the features on the new forked repo
 
+  codeql:
+    runs-on: ubuntu-latest
+    needs: fork-action-test
+    env:
+      owner: rajbos-actions-test # todo: make central parameter
+    steps:
     # todo: what if the action.yml indicates it runs in a docker image? Then we have not neccesarily a way to run CodeQL on actual CODE
+    - uses: actions/checkout@v2
     - uses: actions/github-script@v5
       name: Inject CodeQL workflow into new forked repository
-      # todo: clear all other workflows first
-      id: CodeQL
-      env:
-        owner: rajbos-actions-test # todo: make central parameter
+      # todo: clear all other workflows first, to prevent them from running
+      id: CodeQL-inject      
       with:      
         github-token: ${{ secrets.GH_TOKEN }}  
         script: |
@@ -229,3 +234,23 @@ jobs:
            const owner = process.env.owner
            const repo = "${{ needs.find-action-name.outputs.name }}"
            console.log(await script({github, owner, repo}))
+
+    - name: Wait for CodeQL workflow to completed
+      run: |
+        echo "Waiting for CodeQL workflow to complete"
+        sleep 3m
+
+    - uses: actions/github-script@v5
+      name: Get resuls from CodeQL scan
+      id: get-codeql-results
+      with:
+        github-token: ${{ secrets.GH_TOKEN }}
+        script: |
+           const script = require('./src/get-codeql-results.js')
+                  
+           // note: owner is now the organization the FORK lives in:
+           const owner = process.env.owner
+           const repo = "${{ needs.find-action-name.outputs.request_repo }}"
+
+           console.log(await script({github, owner, repo}))        
+

--- a/.github/workflows/issue-labeled-as-security-scan.yml
+++ b/.github/workflows/issue-labeled-as-security-scan.yml
@@ -216,7 +216,9 @@ jobs:
 
   codeql:
     runs-on: ubuntu-latest
-    needs: fork-action-test
+    needs: 
+      - fork-action-test
+      - find-action-name
     env:
       owner: rajbos-actions-test # todo: make central parameter
     steps:

--- a/src/wait-on-codeql-run.js
+++ b/src/wait-on-codeql-run.js
@@ -2,6 +2,7 @@ module.exports = async ({github, owner, repo}) => {
 
     console.log(`Looking at this repository: [${owner}/${repo}]`)
 
+    let data
     try {
         console.log(`before the call`)
         let { data } = await github.rest.actions.listWorkflowRunsForRepo({ 
@@ -23,3 +24,24 @@ module.exports = async ({github, owner, repo}) => {
     }
     console.log(`after the catch`)
 }
+
+if (data === undefined) {
+    return 1
+}
+
+codeqlRuns = data.workflow_runs.filter(run => run.name === 'CodeQL')
+console.log(`codeqlRuns: ${JSON.stringify(codeqlRuns)}`)
+
+// get the most recent one, is always on top:
+codeQLRun = codeqlRuns[0]
+console.log(`codeQLRun info: id: [${codeQLRun.id}], status: : [${codeQLRun.status}], created_at: [${codeQLRun.created_at}], conclusion: : [${codeQLRun.conclusion}], workflow_id: [${codeqlRun.workflow_id}]`)
+
+// manually dispatch the workflow again, so that we can wait for it
+let { data } = await github.rest.actions.createWorkflowDispatch({
+    owner,
+    repo,
+    workflow_id: codeqlRun.workflow_id,
+    ref: codeqlRun.head_branch,
+  });
+
+  console.log(`Start workflow result data: [${JSON.stringify(data)}]`)

--- a/src/wait-on-codeql-run.js
+++ b/src/wait-on-codeql-run.js
@@ -20,8 +20,10 @@ module.exports = async ({github, owner, repo}) => {
         console.log(e)
     }
     console.log(`after the catch`)
-
+    console.log(`data:`)
+    console.log(data)    
     if (data === undefined) {
+        console.log(`data is undefined`)
         return 1
     }
 

--- a/src/wait-on-codeql-run.js
+++ b/src/wait-on-codeql-run.js
@@ -60,7 +60,7 @@ module.exports = async ({github, owner, repo}) => {
         console.log(`CodeQL run information of run with id: [${run_id}], status: [${data.data.status}] and conclusion: [${data.data.conclusion}]`)
         if (data.data.status !== 'completed') {
             await wait(60000)
-            await waitForScan(run_id)
+            await waitForScan(github, owner, repo, run_id)
         } else {
             if (data.data.conclusion !== 'success' && data.data.conclusion !== null) {
             throw new Error(`${data.data.name} concluded with status ${data.data.conclusion} (${data.data.html_url}).`)

--- a/src/wait-on-codeql-run.js
+++ b/src/wait-on-codeql-run.js
@@ -62,11 +62,12 @@ module.exports = async ({github, owner, repo}) => {
             await wait(60000)
             await waitForScan(github, owner, repo, run_id)
         } else {
+            // currently this fails in the test example: only one job is successful and the rest fails. We should do something with that :-)
             if (data.data.conclusion !== 'success' && data.data.conclusion !== null) {
-            throw new Error(`${data.data.name} concluded with status ${data.data.conclusion} (${data.data.html_url}).`)
+            throw new Error(`${data.data.name} concluded with status ${data.data.conclusion} ${data.data.html_url}`)
             }
             else {
-                console.log(`${data.data.name} concluded with status ${data.data.conclusion} (${data.data.html_url}).`)
+                console.log(`${data.data.name} concluded with status ${data.data.conclusion} ${data.data.html_url}`)
             }
         }
     }

--- a/src/wait-on-codeql-run.js
+++ b/src/wait-on-codeql-run.js
@@ -36,7 +36,7 @@ module.exports = async ({github, owner, repo}) => {
     console.log(`Start workflow result data: [${JSON.stringify(dispatchData.data)}]`)
 
     // wait for the workflow to be started
-    await this.wait(5000)
+    await wait(5000)
 
     // retrieve the last run (should be the new one)
     // todo: check if the newRun.id is not the same as oldrun.id
@@ -49,23 +49,32 @@ module.exports = async ({github, owner, repo}) => {
     
     async function waitForScan(github, owner, repo, run_id) {
         const {
-          data: {name, status, conclusion, html_url}
+            data: {name, status, conclusion, html_url}
         } = await github.rest.actions.getWorkflowRun({
-          owner,
-          repo,
-          run_id
+            owner,
+            repo,
+            run_id
         })
 
         if (status !== 'completed') {
-          await this.wait(60000)
-          await this.waitForScan(run_id)
+            await this.wait(60000)
+            await this.waitForScan(run_id)
         } else {
-          if (conclusion !== 'success' && conclusion !== null) {
+            if (conclusion !== 'success' && conclusion !== null) {
             throw new Error(`${name} concluded with status ${conclusion} (${html_url}).`)
-          }
-          else {
-              console.log(`${name} concluded with status ${conclusion} (${html_url}).`)
-          }
+            }
+            else {
+                console.log(`${name} concluded with status ${conclusion} (${html_url}).`)
+            }
         }
-      }
+    }
+
+    function wait(milliseconds) {
+        return new Promise(_resolve => {
+          if (typeof milliseconds !== 'number') {
+            throw new Error('milliseconds not a number')
+          }
+          setTimeout(() => _resolve('done!'), milliseconds)
+        })
+    }
 }

--- a/src/wait-on-codeql-run.js
+++ b/src/wait-on-codeql-run.js
@@ -23,7 +23,7 @@ module.exports = async ({github, owner, repo}) => {
     console.log(`codeQLRun info: id: [${codeQLRun.id}], status: [${codeQLRun.status}], created_at: [${codeQLRun.created_at}], conclusion: [${codeQLRun.conclusion}], workflow_id: [${codeQLRun.workflow_id}]`)
 
     // manually dispatch the workflow again, so that we can wait for it
-    let { dispatchData } = await github.rest.actions.createWorkflowDispatch({
+    let dispatchData = await github.rest.actions.createWorkflowDispatch({
         owner,
         repo,
         workflow_id: codeQLRun.workflow_id,

--- a/src/wait-on-codeql-run.js
+++ b/src/wait-on-codeql-run.js
@@ -17,11 +17,10 @@ module.exports = async ({github, owner, repo}) => {
     }
 
     codeqlRuns = data.workflow_runs.filter(run => run.name === 'CodeQL')
-    console.log(`codeqlRuns: ${JSON.stringify(codeqlRuns)}`)
 
     // get the most recent one, is always on top:
     codeQLRun = codeqlRuns[0]
-    console.log(`codeQLRun info: id: [${codeQLRun.id}], status: : [${codeQLRun.status}], created_at: [${codeQLRun.created_at}], conclusion: : [${codeQLRun.conclusion}], workflow_id: [${codeqlRun.workflow_id}]`)
+    console.log(`codeQLRun info: id: [${codeQLRun.id}], status: : [${codeQLRun.status}], created_at: [${codeQLRun.created_at}], conclusion: : [${codeQLRun.conclusion}], workflow_id: [${codeQLRun.workflow_id}]`)
 
     // manually dispatch the workflow again, so that we can wait for it
     let { dispatchData } = await github.rest.actions.createWorkflowDispatch({

--- a/src/wait-on-codeql-run.js
+++ b/src/wait-on-codeql-run.js
@@ -1,0 +1,25 @@
+module.exports = async ({github, owner, repo}) => {
+
+    console.log(`Looking at this repository: [${owner}/${repo}]`)
+
+    try {
+        console.log(`before the call`)
+        let { data } = await github.rest.actions.listWorkflowRunsForRepo({ 
+            owner,
+            repo
+        })
+        console.log(`after the call`)
+
+        console.log(`data:`)
+        console.log(data)
+        
+        console.log(`data.content:`)
+        console.log(data.content)
+    }
+    catch (e) {
+        // strange: seems like we are not getting here at all :-(
+        console.log(`in the catch with e:`)
+        console.log(e)
+    }
+    console.log(`after the catch`)
+}

--- a/src/wait-on-codeql-run.js
+++ b/src/wait-on-codeql-run.js
@@ -6,9 +6,6 @@ module.exports = async ({github, owner, repo}) => {
             repo
         })
 
-        console.log(`data:`)
-        console.log(data)        
-
         if (data === undefined) {
             console.log(`data is undefined`)
             return 1
@@ -19,6 +16,7 @@ module.exports = async ({github, owner, repo}) => {
         // get the most recent one, is always on top:
         codeQLRun = codeqlRuns[0]
         console.log(`codeQLRun info: id: [${codeQLRun.id}], status: [${codeQLRun.status}], created_at: [${codeQLRun.created_at}], conclusion: [${codeQLRun.conclusion}], workflow_id: [${codeQLRun.workflow_id}]`)
+        return codeQLRun
     }
     
     console.log(`Looking at this repository: [${owner}/${repo}]`)
@@ -47,7 +45,7 @@ module.exports = async ({github, owner, repo}) => {
     console.log(`lastRun: ${lastRun}`)
 
     // wait for the workflow to finish
-    waitForScan(github, owner, repo, lastRun.id)
+    await waitForScan(github, owner, repo, lastRun.id)
     
     async function waitForScan(github, owner, repo, run_id) {
         const {

--- a/src/wait-on-codeql-run.js
+++ b/src/wait-on-codeql-run.js
@@ -44,18 +44,20 @@ module.exports = async ({github, owner, repo}) => {
     // todo: check if the newRun.id is not the same as oldrun.id
     // todo: handle longer starting of the run as well?
     lastRun = await getLastRun(github, owner, repo)
-    console.log(`lastRun: ${JSON.stringify(lastRun)}`)
+    console.log(`lastRun.id: ${lastRun.id}`)
 
     // wait for the workflow to finish
     await waitForScan(github, owner, repo, lastRun.id)
     
     async function waitForScan(github, owner, repo, run_id) {
+        console.log(`Waiting for the CodeQL run to finish: [${run_id}]`)
         const data  = await github.rest.actions.getWorkflowRun({
             owner,
             repo,
             run_id
         })
-
+        
+        console.log(`CodeQL run information of run with id: [${run_id}], status: [${data.data.status}] and conclusion: [${data.data.conclusion}]`)
         if (data.data.status !== 'completed') {
             await wait(60000)
             await waitForScan(run_id)

--- a/src/wait-on-codeql-run.js
+++ b/src/wait-on-codeql-run.js
@@ -12,10 +12,7 @@ module.exports = async ({github, owner, repo}) => {
         console.log(`after the call`)
 
         console.log(`data:`)
-        console.log(data)
-        
-        console.log(`data.content:`)
-        console.log(data.content)
+        console.log(data)        
     }
     catch (e) {
         // strange: seems like we are not getting here at all :-(

--- a/src/wait-on-codeql-run.js
+++ b/src/wait-on-codeql-run.js
@@ -5,14 +5,16 @@ module.exports = async ({github, owner, repo}) => {
     let data
     try {
         console.log(`before the call`)
-        let { data } = await github.rest.actions.listWorkflowRunsForRepo({ 
+        let data  = await github.rest.actions.listWorkflowRunsForRepo({ 
             owner,
             repo
         })
         console.log(`after the call`)
 
         console.log(`data:`)
-        console.log(data)        
+        console.log(data)      
+        console.log(`data.content:`)
+        console.log(data.content)
     }
     catch (e) {
         // strange: seems like we are not getting here at all :-(

--- a/src/wait-on-codeql-run.js
+++ b/src/wait-on-codeql-run.js
@@ -50,23 +50,21 @@ module.exports = async ({github, owner, repo}) => {
     await waitForScan(github, owner, repo, lastRun.id)
     
     async function waitForScan(github, owner, repo, run_id) {
-        const {
-            data: {name, status, conclusion, html_url}
-        } = await github.rest.actions.getWorkflowRun({
+        const data  = await github.rest.actions.getWorkflowRun({
             owner,
             repo,
             run_id
         })
 
-        if (status !== 'completed') {
+        if (data.data.status !== 'completed') {
             await wait(60000)
             await waitForScan(run_id)
         } else {
-            if (conclusion !== 'success' && conclusion !== null) {
-            throw new Error(`${name} concluded with status ${conclusion} (${html_url}).`)
+            if (data.data.conclusion !== 'success' && data.data.conclusion !== null) {
+            throw new Error(`${data.data.name} concluded with status ${data.data.conclusion} (${data.data.html_url}).`)
             }
             else {
-                console.log(`${name} concluded with status ${conclusion} (${html_url}).`)
+                console.log(`${data.data.name} concluded with status ${data.data.conclusion} (${data.data.html_url}).`)
             }
         }
     }

--- a/src/wait-on-codeql-run.js
+++ b/src/wait-on-codeql-run.js
@@ -23,25 +23,26 @@ module.exports = async ({github, owner, repo}) => {
         console.log(e)
     }
     console.log(`after the catch`)
+
+    if (data === undefined) {
+        return 1
+    }
+
+    codeqlRuns = data.workflow_runs.filter(run => run.name === 'CodeQL')
+    console.log(`codeqlRuns: ${JSON.stringify(codeqlRuns)}`)
+
+    // get the most recent one, is always on top:
+    codeQLRun = codeqlRuns[0]
+    console.log(`codeQLRun info: id: [${codeQLRun.id}], status: : [${codeQLRun.status}], created_at: [${codeQLRun.created_at}], conclusion: : [${codeQLRun.conclusion}], workflow_id: [${codeqlRun.workflow_id}]`)
+
+    // manually dispatch the workflow again, so that we can wait for it
+    let { data } = await github.rest.actions.createWorkflowDispatch({
+        owner,
+        repo,
+        workflow_id: codeqlRun.workflow_id,
+        ref: codeqlRun.head_branch,
+    });
+
+    console.log(`Start workflow result data: [${JSON.stringify(data)}]`)
+
 }
-
-if (data === undefined) {
-    return 1
-}
-
-codeqlRuns = data.workflow_runs.filter(run => run.name === 'CodeQL')
-console.log(`codeqlRuns: ${JSON.stringify(codeqlRuns)}`)
-
-// get the most recent one, is always on top:
-codeQLRun = codeqlRuns[0]
-console.log(`codeQLRun info: id: [${codeQLRun.id}], status: : [${codeQLRun.status}], created_at: [${codeQLRun.created_at}], conclusion: : [${codeQLRun.conclusion}], workflow_id: [${codeqlRun.workflow_id}]`)
-
-// manually dispatch the workflow again, so that we can wait for it
-let { data } = await github.rest.actions.createWorkflowDispatch({
-    owner,
-    repo,
-    workflow_id: codeqlRun.workflow_id,
-    ref: codeqlRun.head_branch,
-  });
-
-  console.log(`Start workflow result data: [${JSON.stringify(data)}]`)

--- a/src/wait-on-codeql-run.js
+++ b/src/wait-on-codeql-run.js
@@ -2,28 +2,15 @@ module.exports = async ({github, owner, repo}) => {
 
     console.log(`Looking at this repository: [${owner}/${repo}]`)
 
-    let data
-    try {
-        console.log(`before the call`)
-        let data  = await github.rest.actions.listWorkflowRunsForRepo({ 
-            owner,
-            repo
-        })
-        console.log(`after the call`)
+    console.log(`before the call`)
+    let { data } = await github.rest.actions.listWorkflowRunsForRepo({ 
+        owner,
+        repo
+    })
 
-        console.log(`data:`)
-        console.log(data)      
-        console.log(`data.content:`)
-        console.log(data.content)
-    }
-    catch (e) {
-        // strange: seems like we are not getting here at all :-(
-        console.log(`in the catch with e:`)
-        console.log(e)
-    }
-    console.log(`after the catch`)
     console.log(`data:`)
-    console.log(data)    
+    console.log(data)        
+
     if (data === undefined) {
         console.log(`data is undefined`)
         return 1

--- a/src/wait-on-codeql-run.js
+++ b/src/wait-on-codeql-run.js
@@ -20,14 +20,14 @@ module.exports = async ({github, owner, repo}) => {
 
     // get the most recent one, is always on top:
     codeQLRun = codeqlRuns[0]
-    console.log(`codeQLRun info: id: [${codeQLRun.id}], status: : [${codeQLRun.status}], created_at: [${codeQLRun.created_at}], conclusion: : [${codeQLRun.conclusion}], workflow_id: [${codeQLRun.workflow_id}]`)
+    console.log(`codeQLRun info: id: [${codeQLRun.id}], status: [${codeQLRun.status}], created_at: [${codeQLRun.created_at}], conclusion: [${codeQLRun.conclusion}], workflow_id: [${codeQLRun.workflow_id}]`)
 
     // manually dispatch the workflow again, so that we can wait for it
     let { dispatchData } = await github.rest.actions.createWorkflowDispatch({
         owner,
         repo,
-        workflow_id: codeqlRun.workflow_id,
-        ref: codeqlRun.head_branch,
+        workflow_id: codeQLRun.workflow_id,
+        ref: codeQLRun.head_branch,
     });
 
     console.log(`Start workflow result data: [${JSON.stringify(dispatchData)}]`)

--- a/src/wait-on-codeql-run.js
+++ b/src/wait-on-codeql-run.js
@@ -36,13 +36,13 @@ module.exports = async ({github, owner, repo}) => {
     console.log(`codeQLRun info: id: [${codeQLRun.id}], status: : [${codeQLRun.status}], created_at: [${codeQLRun.created_at}], conclusion: : [${codeQLRun.conclusion}], workflow_id: [${codeqlRun.workflow_id}]`)
 
     // manually dispatch the workflow again, so that we can wait for it
-    let { data } = await github.rest.actions.createWorkflowDispatch({
+    let { dispatchData } = await github.rest.actions.createWorkflowDispatch({
         owner,
         repo,
         workflow_id: codeqlRun.workflow_id,
         ref: codeqlRun.head_branch,
     });
 
-    console.log(`Start workflow result data: [${JSON.stringify(data)}]`)
+    console.log(`Start workflow result data: [${JSON.stringify(dispatchData)}]`)
 
 }

--- a/src/wait-on-codeql-run.js
+++ b/src/wait-on-codeql-run.js
@@ -1,35 +1,73 @@
 module.exports = async ({github, owner, repo}) => {
 
-    console.log(`Looking at this repository: [${owner}/${repo}]`)
+    async function getLastRun(github, owner, repo) {
+        let { data } = await github.rest.actions.listWorkflowRunsForRepo({ 
+            owner,
+            repo
+        })
 
-    console.log(`before the call`)
-    let { data } = await github.rest.actions.listWorkflowRunsForRepo({ 
-        owner,
-        repo
-    })
+        console.log(`data:`)
+        console.log(data)        
 
-    console.log(`data:`)
-    console.log(data)        
+        if (data === undefined) {
+            console.log(`data is undefined`)
+            return 1
+        }
 
-    if (data === undefined) {
-        console.log(`data is undefined`)
-        return 1
+        codeqlRuns = data.workflow_runs.filter(run => run.name === 'CodeQL')
+
+        // get the most recent one, is always on top:
+        codeQLRun = codeqlRuns[0]
+        console.log(`codeQLRun info: id: [${codeQLRun.id}], status: [${codeQLRun.status}], created_at: [${codeQLRun.created_at}], conclusion: [${codeQLRun.conclusion}], workflow_id: [${codeQLRun.workflow_id}]`)
     }
-
-    codeqlRuns = data.workflow_runs.filter(run => run.name === 'CodeQL')
-
-    // get the most recent one, is always on top:
-    codeQLRun = codeqlRuns[0]
-    console.log(`codeQLRun info: id: [${codeQLRun.id}], status: [${codeQLRun.status}], created_at: [${codeQLRun.created_at}], conclusion: [${codeQLRun.conclusion}], workflow_id: [${codeQLRun.workflow_id}]`)
+    
+    console.log(`Looking at this repository: [${owner}/${repo}]`)
+    lastRun = await getLastRun(github, owner, repo)
+    console.log(`lastRun: ${lastRun}`)
 
     // manually dispatch the workflow again, so that we can wait for it
     let dispatchData = await github.rest.actions.createWorkflowDispatch({
         owner,
         repo,
-        workflow_id: codeQLRun.workflow_id,
-        ref: codeQLRun.head_branch,
+        workflow_id: lastRun.workflow_id,
+        ref: lastRun.head_branch,
     });
 
-    console.log(`Start workflow result data: [${JSON.stringify(dispatchData)}]`)
+    // todo: check if result is a 204 (data is empty)
+    console.log(`Start workflow result: [${JSON.stringify(dispatchData)}]`)
+    console.log(`Start workflow result data: [${JSON.stringify(dispatchData.data)}]`)
 
+    // wait for the workflow to be started
+    await this.wait(5000)
+
+    // retrieve the last run (should be the new one)
+    // todo: check if the newRun.id is not the same as oldrun.id
+    // todo: handle longer starting of the run as well?
+    lastRun = await getLastRun(github, owner, repo)
+    console.log(`lastRun: ${lastRun}`)
+
+    // wait for the workflow to finish
+    waitForScan(github, owner, repo, lastRun.id)
+    
+    async function waitForScan(github, owner, repo, run_id) {
+        const {
+          data: {name, status, conclusion, html_url}
+        } = await github.rest.actions.getWorkflowRun({
+          owner,
+          repo,
+          run_id
+        })
+
+        if (status !== 'completed') {
+          await this.wait(60000)
+          await this.waitForScan(run_id)
+        } else {
+          if (conclusion !== 'success' && conclusion !== null) {
+            throw new Error(`${name} concluded with status ${conclusion} (${html_url}).`)
+          }
+          else {
+              console.log(`${name} concluded with status ${conclusion} (${html_url}).`)
+          }
+        }
+      }
 }

--- a/src/wait-on-codeql-run.js
+++ b/src/wait-on-codeql-run.js
@@ -31,9 +31,11 @@ module.exports = async ({github, owner, repo}) => {
         ref: lastRun.head_branch,
     });
 
-    // todo: check if result is a 204 (data is empty)
-    console.log(`Start workflow result: [${JSON.stringify(dispatchData)}]`)
-    console.log(`Start workflow result data: [${JSON.stringify(dispatchData.data)}]`)
+    if (dispatchData.status !== 204) {	
+        console.log(`Error starting the CodeQL workflow dispatch:`)
+        console.log(`Start workflow result: [${JSON.stringify(dispatchData)}]`)
+        return 1
+    }
 
     // wait for the workflow to be started
     await wait(5000)
@@ -42,7 +44,7 @@ module.exports = async ({github, owner, repo}) => {
     // todo: check if the newRun.id is not the same as oldrun.id
     // todo: handle longer starting of the run as well?
     lastRun = await getLastRun(github, owner, repo)
-    console.log(`lastRun: ${lastRun}`)
+    console.log(`lastRun: ${JSON.stringify(lastRun)}`)
 
     // wait for the workflow to finish
     await waitForScan(github, owner, repo, lastRun.id)
@@ -57,8 +59,8 @@ module.exports = async ({github, owner, repo}) => {
         })
 
         if (status !== 'completed') {
-            await this.wait(60000)
-            await this.waitForScan(run_id)
+            await wait(60000)
+            await waitForScan(run_id)
         } else {
             if (conclusion !== 'success' && conclusion !== null) {
             throw new Error(`${name} concluded with status ${conclusion} (${html_url}).`)


### PR DESCRIPTION
Dispatching and checking the execution has been creating. for #2. 

Todo:
- [ ] Check the individual jobs for the results, before failing this javascript check
- [ ] Remove the dispatch on push from the template
- [ ] Trigger the workflow by filename, instead of by id, since we will not be able to get the id with the previous action 